### PR TITLE
Focus-state should be outlined due to accessibility reasons

### DIFF
--- a/css/responsiveboilerplate.css
+++ b/css/responsiveboilerplate.css
@@ -91,7 +91,7 @@ img {height: auto;}
 
 /* Links (No outline borders) 
 ============================================================================================== */
-a:focus, a:hover, a:active {outline: 0;}
+a:hover, a:active {outline: 0;}
 
 /* Responsive Navigation Basic Style 
 ----------------------------------------------------------------------------------------------------*/


### PR DESCRIPTION
I don't see a reason to disable outlining of anchor-elements. 
