### PR TITLE
Remove Scheme of jQuery CDN URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
 		<!--Also on the same folder of this file have a demo.html with a basic style just for preview the columns-->
 </div>
 <!-- JavaScript at the bottom for fast page loading -->
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="libs/jquery-1.10.1.min.js"><\/script>')</script>
 <script src="js/custom.js"></script>
 


### PR DESCRIPTION
This is used to work correctly independent of protocol HTTP/HTTPS.
Reference: http://www.ietf.org/rfc/rfc3986.txt
